### PR TITLE
Midpoint, calculation simplification.

### DIFF
--- a/demo/components/Scene.vue
+++ b/demo/components/Scene.vue
@@ -237,8 +237,8 @@ function loop() {
 
 function midPointBtw(p1: Point, p2: Point) {
   return {
-    x: p1.x + (p2.x - p1.x) / 2,
-    y: p1.y + (p2.y - p1.y) / 2
+    x: (p2.x + p1.x) / 2,
+    y: (p2.y + p1.y) / 2
   }
 }
 


### PR DESCRIPTION
The midPointBtw calculation p1+ (p2 - p1) / 2, is equivalent to the simplification (p2 + p1) / 2.
Saving you an operation.